### PR TITLE
fix python < 3.9 bug

### DIFF
--- a/core/replay.py
+++ b/core/replay.py
@@ -65,7 +65,7 @@ class Replay:
         for k, v in self.__parse_cookie(new_cookie).items():
             flow.request.cookies[k] = v
     
-    def __match_replace(self, flow: http.HTTPFlow, mrs: list[dict]) -> None:
+    def __match_replace(self, flow: http.HTTPFlow, mrs: list) -> None:
         # Match and replace here.
         for mr in mrs:
             pattern = re.compile(mr['pattern'])


### PR DESCRIPTION
issue: https://github.com/y1nglamore/IDOR_detect_tool/issues/3

原因是Python3.9以下不支持一个特性：
```python
a : list[dict] = [{}]
```

![m1-170525_s0ZCU6](http://cdn2.pic.y1ng.vip/uPic/2023/02/03/m1-170525_s0ZCU6.png)
![m1-170538_OzvG9t](http://cdn2.pic.y1ng.vip/uPic/2023/02/03/m1-170538_OzvG9t.png)